### PR TITLE
Constructors for sphere coordinates, and tests

### DIFF
--- a/where.go
+++ b/where.go
@@ -497,6 +497,16 @@ type SphereCoordinate struct {
 	longitude  float64
 }
 
+// Create a SphereCoordinate structure from a latitude/longitude pair.
+func NewLatLonCoordinate(lat float64, lon float64) SphereCoordinate {
+	return SphereCoordinate{lat, lat + math.Pi/2, lon}
+}
+
+// Create a SphereCoordinate structure from a colatitude/longitude pair.
+func NewColatLonCoordinate(colat float64, lon float64) SphereCoordinate {
+	return SphereCoordinate{colat - math.Pi/2, colat, lon}
+}
+
 // The latitude component of the coordinate on the sphere, in units of radians.
 func (p SphereCoordinate) Latitude() float64 {
 	return p.latitude

--- a/where_test.go
+++ b/where_test.go
@@ -359,6 +359,27 @@ func TestRingCoordToFacePixelInvertible(t *testing.T) {
 	}
 }
 
+func TestSphereConstructorsSame(t *testing.T) {
+	latToColatSame := func(latitude float64, longitude float64) bool {
+		latLon := NewLatLonCoordinate(latitude, longitude)
+		colatLon := NewColatLonCoordinate(latLon.Colatitude(), latLon.Longitude())
+		return withinTolerance(latLon.Latitude(), colatLon.Latitude(), 0.000000001)
+	}
+
+	colatToLatSame := func(colatitude float64, longitude float64) bool {
+		colatLon := NewColatLonCoordinate(colatitude, longitude)
+		latLon := NewLatLonCoordinate(colatLon.Latitude(), colatLon.Longitude())
+		return withinTolerance(latLon.Latitude(), colatLon.Latitude(), 0.000000001)
+	}
+
+	if err := quick.Check(latToColatSame, nil); err != nil {
+		t.Errorf("Latitude was different after converted to colatitude and back: %v", err)
+	}
+	if err := quick.Check(colatToLatSame, nil); err != nil {
+		t.Errorf("Colatitude was different after converted to latitude and back: %v", err)
+	}
+}
+
 func TestConversionInverses(t *testing.T) {
 	hp := NewHealpixOrder(MaxOrder())
 


### PR DESCRIPTION
The convenience constructors for the `SphereCoordinate` data type added here help maintain the assumed invariant between `Latitude()` and `Colatitude()`. Previously, the developer had to remember to supply both latitude and colatitude, even though if you know one it is easy for the library to know the other.

In short, this MR implements that easiness so developers don't have to.